### PR TITLE
Two small fixes

### DIFF
--- a/Invoke-Bof.ps1
+++ b/Invoke-Bof.ps1
@@ -1027,6 +1027,26 @@ Invoke-Bof -BOFBytes $BOFBytes -EntryPoint go -ArgumentList "foo",5
             Write-Debug "[+] Resolving BeaconSpawnTemporaryProcess"
             return [System.Runtime.InteropServices.Marshal]::GetFunctionPointerForDelegate($BeaconAPI.toWideChar)
         }
+        elseif($Symbol -eq "__imp_GetProcAddress")
+        {
+            Write-Debug "[+] Resolving GetProcAddress"
+            $Name = "__imp_KERNEL32`$GetProcAddress"
+        }
+        elseif($Symbol -eq "__imp_LoadLibraryA")
+        {
+            Write-Debug "[+] Resolving LoadLibraryA"
+            $Name = "__imp_KERNEL32`$LoadLibraryA"
+        }
+        elseif($Symbol -eq "__imp_FreeLibrary")
+        {
+            Write-Debug "[+] Resolving FreeLibrary"
+            $Name = "__imp_KERNEL32`$FreeLibrary"
+        }
+        elseif($Symbol -eq "__imp_GetModuleHandleA")
+        {
+            Write-Debug "[+] Resolving GetModuleHandleA"
+            $Name = "__imp_KERNEL32`$GetModuleHandleA"
+        }
 
         # If it's not part of the beacon API
         # we will try to resolve it

--- a/Invoke-Bof.ps1
+++ b/Invoke-Bof.ps1
@@ -1453,7 +1453,7 @@ Invoke-Bof -BOFBytes $BOFBytes -EntryPoint go -ArgumentList "foo",5
     # Marshal parameters in memory
     $ArgumentsBytes = [IntPtr]::Zero;
     $ArgumentsBytesLength = 0
-    if ($ArgumentList -ne $null)
+    if ($null -ne $ArgumentList)
     {
         $ArgumentsBytes, $ArgumentsBytesLength = Load-BeaconParameters -ArgumentList $ArgumentList -UnicodeStringParameter $UnicodeStringParameter
     }


### PR DESCRIPTION
**Fix 1**
There is a subtle error in the passing of parameters to the BOF. The bug happens when a BOF accepts only 1 parameter and it is set to `0` or `""`. In this case the `-ArgumentList` is ignored instead of being parsed. Fixed by switching the order of the operands when checking for `$null`. (see: https://learn.microsoft.com/en-us/powershell/scripting/learn/deep-dives/everything-about-null?view=powershell-7.4#when-i-null-check) 

- Tested fix with: https://github.com/trustedsec/CS-Situational-Awareness-BOF/tree/master/SA/enum_filter_driver

**Fix 2**
Accoording to the Forta documentation BOFs may assume that the functions `GetProcAddress`, `LoadLibraryA`, `GetModuleHandleA` and `FreeLibrary` are available without DFR (see: https://hstechdocs.helpsystems.com/manuals/cobaltstrike/current/userguide/content/topics/beacon-object-files_dynamic-func-resolution.htm). Added some logic to Resolve-Extern to handle this.

- Tested fix with: https://github.com/trustedsec/CS-Situational-Awareness-BOF/tree/master/SA/ldapsearch